### PR TITLE
Refine time system and Dina support

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -123,6 +123,13 @@ body {
   font-size: 1rem;
 }
 
+.status-description {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(248, 250, 252, 0.68);
+  line-height: 1.4;
+}
+
 .status-card--meter .status-value {
   font-size: 0.95rem;
 }
@@ -346,6 +353,21 @@ body {
   background: rgba(248, 250, 252, 0.8);
   padding: 0.15rem 0.55rem;
   border-radius: 999px;
+}
+
+.choice-duration {
+  font-size: 0.78rem;
+  color: rgba(248, 250, 252, 0.85);
+  font-weight: 500;
+}
+
+.choice-note {
+  font-size: 0.78rem;
+  color: rgba(248, 250, 252, 0.78);
+  background: rgba(15, 23, 42, 0.55);
+  padding: 0.35rem 0.55rem;
+  border-radius: 8px;
+  border-left: 3px solid rgba(56, 189, 248, 0.6);
 }
 
 .restart {


### PR DESCRIPTION
## Summary
- add calendar-aware timekeeping, varied action durations, and inline descriptions for fatigue, stress, and other meters
- make action outcomes react to current stats/fatigue and expose duration hints plus contextual notes in the choice list
- expand Dina’s support arc with loan tracking, follow-up actions, reminders, and a toned-down overtime payout for better balance

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e4e1c4abb8832d89f1c6505d3dc2ad