### PR TITLE
Fix stats panel and journal toggles

### DIFF
--- a/scripts/game/engine.js
+++ b/scripts/game/engine.js
@@ -46,15 +46,22 @@ export function initializeGame() {
   journalPanel = document.getElementById("journalPanel");
   miniMapContainer = document.getElementById("miniMap");
 
+  if (toggleStatsButton && statsElement) {
+    toggleStatsButton.setAttribute("aria-controls", statsElement.id);
+    statsPanelVisible = !statsElement.hasAttribute("hidden");
+  }
+
   buildMetadata();
   initializeStatsUI(statsElement, stats);
   initializeStatusPanel(statusMetricsElement, worldState);
   initializeMiniMap(miniMapContainer);
   initializeJournal(journalButton, journalPanel, () => buildJournalEntries());
 
-  toggleStatsButton.addEventListener("click", () => {
-    setStatsPanelVisibility(!statsPanelVisible);
-  });
+  if (toggleStatsButton && statsElement) {
+    toggleStatsButton.addEventListener("click", () => {
+      setStatsPanelVisibility(!statsPanelVisible);
+    });
+  }
 
   restartButton.addEventListener("click", () => {
     resetGame();
@@ -881,14 +888,21 @@ function setStatsPanelVisibility(visible) {
   if (statsPanelVisible) {
     statsElement.hidden = false;
     statsElement.removeAttribute("hidden");
+    statsElement.setAttribute("aria-hidden", "false");
+    if (typeof statsElement.scrollIntoView === "function" && statsElement.isConnected) {
+      statsElement.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
   } else {
     statsElement.hidden = true;
     if (!statsElement.hasAttribute("hidden")) {
       statsElement.setAttribute("hidden", "");
     }
+    statsElement.setAttribute("aria-hidden", "true");
   }
 
-  toggleStatsButton.setAttribute("aria-expanded", statsPanelVisible ? "true" : "false");
+  const expanded = statsPanelVisible ? "true" : "false";
+  toggleStatsButton.setAttribute("aria-expanded", expanded);
+  toggleStatsButton.setAttribute("aria-pressed", expanded);
   toggleStatsButton.textContent = statsPanelVisible
     ? "Sembunyikan Stat Karakter"
     : "Tampilkan Stat Karakter";


### PR DESCRIPTION
## Summary
- synchronize the stats toggle button with the panel state, wire up aria attributes, and auto-scroll the panel when shown
- harden journal initialization, centralize its toggle logic, and ensure aria visibility stays accurate while refreshing entries

## Testing
- npm run build:fallback

------
https://chatgpt.com/codex/tasks/task_e_68e5609caa54832db179e01ca1dab69c