### PR TITLE
Make stats and journal overlays draggable floating panels

### DIFF
--- a/scripts/ui/floatingWindow.js
+++ b/scripts/ui/floatingWindow.js
@@ -1,0 +1,128 @@
+const DEFAULT_MARGIN = 24;
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function isInteractiveElement(element) {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+  return Boolean(
+    element.closest(
+      'button, a, input, textarea, select, [data-no-drag], [role="button"], [role="tab"], [role="menuitem"]',
+    ),
+  );
+}
+
+export function createFloatingWindow({ container, modal, handle }) {
+  if (!container || !modal || !handle) {
+    return {
+      center: () => {},
+      destroy: () => {},
+      hasCustomPosition: () => false,
+    };
+  }
+
+  let pointerId = null;
+  let offsetX = 0;
+  let offsetY = 0;
+  let hasCustomPosition = false;
+
+  container.classList.add("floating-overlay");
+  modal.classList.add("floating-window");
+  handle.classList.add("floating-window__handle");
+  handle.style.cursor = "grab";
+
+  function applyCenterPosition() {
+    hasCustomPosition = false;
+    modal.style.transform = "translate(-50%, -50%)";
+    modal.style.left = "50%";
+    modal.style.top = "50%";
+    modal.dataset.dragging = "false";
+    container.dataset.dragging = "false";
+  }
+
+  function updatePosition(clientX, clientY) {
+    const rect = modal.getBoundingClientRect();
+    const availableWidth = window.innerWidth;
+    const availableHeight = window.innerHeight;
+    const minLeft = DEFAULT_MARGIN;
+    const maxLeft = Math.max(minLeft, availableWidth - rect.width - DEFAULT_MARGIN);
+    const minTop = DEFAULT_MARGIN;
+    const maxTop = Math.max(minTop, availableHeight - rect.height - DEFAULT_MARGIN);
+    const clampedLeft = clamp(clientX - offsetX, minLeft, maxLeft);
+    const clampedTop = clamp(clientY - offsetY, minTop, maxTop);
+    modal.style.left = `${clampedLeft}px`;
+    modal.style.top = `${clampedTop}px`;
+  }
+
+  function endDrag(event) {
+    if (pointerId !== null && event.pointerId !== pointerId) {
+      return;
+    }
+    handle.releasePointerCapture?.(pointerId);
+    pointerId = null;
+    handle.style.cursor = "grab";
+    modal.dataset.dragging = "false";
+    container.dataset.dragging = "false";
+    window.removeEventListener("pointermove", handlePointerMove);
+    window.removeEventListener("pointerup", endDrag);
+    window.removeEventListener("pointercancel", endDrag);
+  }
+
+  function handlePointerMove(event) {
+    if (pointerId === null || event.pointerId !== pointerId) {
+      return;
+    }
+    event.preventDefault();
+    hasCustomPosition = true;
+    if (modal.style.transform.includes("-50%")) {
+      const rect = modal.getBoundingClientRect();
+      modal.style.transform = "translate(0, 0)";
+      modal.style.left = `${rect.left}px`;
+      modal.style.top = `${rect.top}px`;
+    }
+    updatePosition(event.clientX, event.clientY);
+  }
+
+  function startDrag(event) {
+    if (pointerId !== null) {
+      return;
+    }
+    if (isInteractiveElement(event.target)) {
+      return;
+    }
+    pointerId = event.pointerId;
+    handle.setPointerCapture?.(pointerId);
+    const rect = modal.getBoundingClientRect();
+    offsetX = event.clientX - rect.left;
+    offsetY = event.clientY - rect.top;
+    modal.dataset.dragging = "true";
+    container.dataset.dragging = "true";
+    handle.style.cursor = "grabbing";
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", endDrag);
+    window.addEventListener("pointercancel", endDrag);
+    event.preventDefault();
+  }
+
+  handle.addEventListener("pointerdown", startDrag);
+
+  const controller = {
+    center: () => {
+      applyCenterPosition();
+    },
+    hasCustomPosition: () => hasCustomPosition,
+    destroy: () => {
+      handle.removeEventListener("pointerdown", startDrag);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", endDrag);
+      window.removeEventListener("pointercancel", endDrag);
+    },
+  };
+
+  applyCenterPosition();
+
+  return controller;
+}

--- a/scripts/ui/statsPanel.js
+++ b/scripts/ui/statsPanel.js
@@ -1,18 +1,77 @@
 import { statsOrder, tierLabels, getTier } from "../config/stats.js";
+import { createFloatingWindow } from "./floatingWindow.js";
 
+const TITLE_ID = "statsDialogTitle";
 const statElements = new Map();
 let containerRef = null;
+let gridRef = null;
+let closeButtonRef = null;
+let floatingController = null;
+let onRequestCloseRef = null;
 
-export function initializeStatsUI(container, stats) {
+function handleCloseClick(event) {
+  event?.preventDefault?.();
+  onRequestCloseRef?.();
+}
+
+export function initializeStatsUI(container, stats, options = {}) {
   if (!container) {
     containerRef = null;
+    gridRef = null;
+    closeButtonRef = null;
+    floatingController?.destroy?.();
+    floatingController = null;
+    onRequestCloseRef = null;
     statElements.clear();
     return;
   }
 
+  onRequestCloseRef = typeof options.onRequestClose === "function" ? options.onRequestClose : null;
+
+  if (closeButtonRef) {
+    closeButtonRef.removeEventListener("click", handleCloseClick);
+  }
+  floatingController?.destroy?.();
+  floatingController = null;
+
   containerRef = container;
   containerRef.innerHTML = "";
+  containerRef.classList.add("stats-panel");
+  containerRef.setAttribute("role", "dialog");
+  containerRef.setAttribute("aria-modal", "false");
+  containerRef.setAttribute("aria-labelledby", TITLE_ID);
+  containerRef.setAttribute("aria-hidden", "true");
+  containerRef.tabIndex = -1;
+  containerRef.hidden = true;
+  containerRef.dataset.open = "false";
+
+  containerRef.innerHTML = `
+    <div class="stats-modal" role="document">
+      <header class="stats-modal__header">
+        <div class="stats-modal__titles">
+          <p class="stats-modal__subtitle">Profil Kepribadian</p>
+          <h2 class="stats-modal__title" id="${TITLE_ID}">Stat Karakter</h2>
+        </div>
+        <button type="button" class="stats-modal__close" aria-label="Tutup stat">
+          <span aria-hidden="true">✕</span>
+        </button>
+      </header>
+      <div class="stats-modal__body">
+        <div class="stats-grid" role="list"></div>
+      </div>
+    </div>
+  `;
+
+  const modalRef = containerRef.querySelector(".stats-modal");
+  const dragHandle = containerRef.querySelector(".stats-modal__header");
+  gridRef = containerRef.querySelector(".stats-grid");
+  closeButtonRef = containerRef.querySelector(".stats-modal__close");
+  floatingController = createFloatingWindow({ container: containerRef, modal: modalRef, handle: dragHandle });
+
+  closeButtonRef?.addEventListener("click", handleCloseClick);
+
   statElements.clear();
+  gridRef.innerHTML = "";
 
   statsOrder.forEach((key) => {
     const stat = stats[key];
@@ -20,6 +79,7 @@ export function initializeStatsUI(container, stats) {
     const card = document.createElement("article");
     card.className = "stat-card";
     card.dataset.stat = key;
+    card.setAttribute("role", "listitem");
     if (stat.color) {
       card.style.setProperty("--stat-color", stat.color);
     }
@@ -67,10 +127,38 @@ export function initializeStatsUI(container, stats) {
     description.textContent = stat.description;
 
     card.append(header, progress, meta, description);
-    containerRef.appendChild(card);
+    gridRef.appendChild(card);
 
     statElements.set(key, { card, bar, progress, value, tier });
   });
+
+  floatingController?.center?.();
+}
+
+export function onStatsVisibilityChange(visible) {
+  if (!containerRef) {
+    return;
+  }
+
+  if (visible) {
+    containerRef.hidden = false;
+    containerRef.removeAttribute("hidden");
+    containerRef.setAttribute("aria-hidden", "false");
+    containerRef.dataset.open = "true";
+    if (floatingController && !floatingController.hasCustomPosition()) {
+      floatingController.center();
+    }
+    window.requestAnimationFrame(() => {
+      closeButtonRef?.focus?.();
+    });
+  } else {
+    containerRef.hidden = true;
+    if (!containerRef.hasAttribute("hidden")) {
+      containerRef.setAttribute("hidden", "");
+    }
+    containerRef.setAttribute("aria-hidden", "true");
+    containerRef.dataset.open = "false";
+  }
 }
 
 export function updateStatsUI(stats) {

--- a/styles.css
+++ b/styles.css
@@ -343,16 +343,7 @@ body {
   background: rgba(255, 231, 179, 0.14);
 }
 
-.stats-panel {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
-  padding: 0.25rem;
-}
 
-.stats-panel[hidden] {
-  display: none;
-}
 
 .stat-card {
   --stat-color: var(--accent);
@@ -361,10 +352,10 @@ body {
   background: var(--surface-strong);
   border: 1px solid var(--stat-color-soft);
   border-radius: 18px;
-  padding: 1.1rem 1.2rem;
+  padding: 0.95rem 1.05rem;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.75rem;
   transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02), 0 18px 32px -28px rgba(8, 7, 20, 0.8);
 }
@@ -414,17 +405,18 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  gap: 0.4rem;
 }
 
 .stat-value {
-  font-size: 1.4rem;
+  font-size: 1.32rem;
   font-weight: 600;
   color: var(--stat-color);
 }
 
 .stat-tier {
-  font-size: 0.75rem;
-  padding: 0.2rem 0.65rem;
+  font-size: 0.72rem;
+  padding: 0.18rem 0.6rem;
   border-radius: 999px;
   background: var(--stat-color-soft);
   color: var(--stat-color);
@@ -435,9 +427,9 @@ body {
 
 .stat-description {
   margin: 0;
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  line-height: 1.5;
+  font-size: 0.78rem;
+  color: rgba(209, 213, 219, 0.74);
+  line-height: 1.45;
 }
 
 .app-main {
@@ -492,18 +484,26 @@ body {
   margin: 0;
   padding: 0;
   list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
+  display: grid;
+  gap: 0.55rem 0.65rem;
+}
+
+.stat-changes {
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.insights {
+  grid-template-columns: 1fr;
 }
 
 .stat-change {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 0.88rem;
-  padding: 0.5rem 0.7rem;
-  border-radius: 12px;
+  gap: 0.45rem;
+  font-size: 0.82rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 11px;
   background: var(--surface-strong);
   border: 1px solid rgba(255, 231, 179, 0.12);
 }
@@ -550,15 +550,41 @@ body {
   border-left: 3px solid rgba(251, 191, 36, 0.65);
 }
 
-.journal-panel {
+
+.floating-overlay {
   position: fixed;
   inset: 0;
-  display: grid;
-  place-items: center;
-  padding: 3.5rem 1.5rem;
-  background: rgba(8, 6, 18, 0.72);
-  backdrop-filter: blur(6px);
+  pointer-events: none;
   z-index: 40;
+}
+
+.floating-overlay[hidden] {
+  display: none;
+}
+
+.floating-window {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: auto;
+}
+
+.floating-window__handle {
+  cursor: grab;
+  touch-action: none;
+}
+
+.floating-overlay[data-dragging="true"] .floating-window,
+.floating-overlay[data-dragging="true"] .floating-window__handle {
+  cursor: grabbing;
+  user-select: none;
+}
+
+.journal-panel {
+  padding: 0;
+  background: transparent;
+  backdrop-filter: none;
 }
 
 .journal-panel[hidden] {
@@ -647,6 +673,89 @@ body {
   gap: 1.25rem;
 }
 
+.stats-panel {
+  padding: 0;
+}
+
+.stats-modal {
+  width: min(720px, 100%);
+  max-height: min(86vh, 760px);
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(160deg, rgba(40, 40, 56, 0.98) 0%, rgba(22, 22, 32, 0.95) 100%);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 231, 179, 0.14);
+  box-shadow: 0 24px 70px rgba(5, 4, 14, 0.55);
+  overflow: hidden;
+}
+
+.stats-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.2rem;
+  padding: 1.6rem 1.8rem 1.2rem;
+  background: linear-gradient(180deg, rgba(48, 48, 64, 0.94) 0%, rgba(30, 30, 42, 0.9) 100%);
+  border-bottom: 1px solid rgba(255, 231, 179, 0.12);
+}
+
+.stats-modal__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.stats-modal__subtitle {
+  margin: 0;
+  font-size: 0.76rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255, 231, 179, 0.52);
+  font-weight: 600;
+}
+
+.stats-modal__title {
+  margin: 0;
+  font-size: 1.3rem;
+  color: rgba(255, 231, 179, 0.92);
+  letter-spacing: 0.02em;
+}
+
+.stats-modal__close {
+  border: 1px solid rgba(255, 231, 179, 0.14);
+  background: rgba(28, 26, 36, 0.6);
+  color: rgba(255, 231, 179, 0.85);
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.stats-modal__close:hover,
+.stats-modal__close:focus-visible {
+  background: rgba(251, 191, 36, 0.22);
+  color: rgba(255, 247, 227, 0.95);
+  transform: translateY(-1px);
+  outline: none;
+  box-shadow: 0 10px 22px rgba(8, 6, 18, 0.45);
+}
+
+.stats-modal__body {
+  padding: 1.35rem 1.8rem 1.8rem;
+  overflow-y: auto;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.9rem 1rem;
+}
+
 .journal-description {
   margin: 0;
   color: rgba(255, 231, 179, 0.72);
@@ -669,6 +778,36 @@ body {
   padding: 1.1rem 1.2rem;
   border: 1px solid rgba(255, 231, 179, 0.14);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 16px 28px rgba(5, 4, 14, 0.4);
+}
+
+.journal-sublist {
+  margin: 0.85rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.journal-sublist li {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: rgba(243, 244, 246, 0.88);
+}
+
+.journal-subtext {
+  flex: 1 1 auto;
+  line-height: 1.55;
+}
+
+.journal-subtime {
+  flex: 0 0 auto;
+  font-size: 0.78rem;
+  color: rgba(255, 231, 179, 0.7);
+  white-space: nowrap;
 }
 
 .journal-list h3 {
@@ -700,12 +839,9 @@ body.modal-open {
 }
 
 @media (max-width: 640px) {
-  .journal-panel {
-    padding: 2.5rem 1rem;
-  }
-
   .journal-modal {
-    max-height: 90vh;
+    width: min(100%, 420px);
+    max-height: 88vh;
     border-radius: 22px;
   }
 
@@ -719,6 +855,20 @@ body.modal-open {
 
   .journal-list {
     padding-left: 1.1rem;
+  }
+
+  .stats-modal {
+    width: min(100%, 420px);
+    max-height: 88vh;
+    border-radius: 22px;
+  }
+
+  .stats-modal__body {
+    padding: 1.15rem 1.35rem 1.55rem;
+  }
+
+  .stats-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 


### PR DESCRIPTION
## Summary
- create a reusable floating window helper and apply it to the journal and stats panels so they open as draggable overlays without blocking gameplay
- restyle the stats modal, stat cards, and feedback change list for a denser layout and rebuild the fallback bundle
- persist condition insights into the journal after their first display so subsequent updates live in the journal instead of the feedback panel

## Testing
- npm run build:fallback

------
https://chatgpt.com/codex/tasks/task_e_68e577478ca0832dbaf0a0819f16cb7e