### PR TITLE
Fix floating modal jump when clicking headers

### DIFF
--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -752,6 +752,7 @@ var GameApp = (() => {
     let modalWidth = 0;
     let modalHeight = 0;
     let hasCustomPosition = false;
+    let isDragging = false;
     container.classList.add("floating-overlay");
     modal.classList.add("floating-window");
     handle.classList.add("floating-window__handle");
@@ -801,8 +802,11 @@ var GameApp = (() => {
       handle.releasePointerCapture?.(pointerId);
       pointerId = null;
       handle.style.cursor = "grab";
-      modal.dataset.dragging = "false";
-      container.dataset.dragging = "false";
+      if (isDragging) {
+        modal.dataset.dragging = "false";
+        container.dataset.dragging = "false";
+      }
+      isDragging = false;
       window.removeEventListener("pointermove", handlePointerMove);
       window.removeEventListener("pointerup", endDrag);
       window.removeEventListener("pointercancel", endDrag);
@@ -813,6 +817,22 @@ var GameApp = (() => {
         return;
       }
       event.preventDefault();
+      if (!isDragging) {
+        if (modal.style.transform.includes("-50%")) {
+          const rect = modal.getBoundingClientRect();
+          modal.style.transform = "translate(0, 0)";
+          modal.style.left = `${rect.left}px`;
+          modal.style.top = `${rect.top}px`;
+          startLeft = rect.left;
+          startTop = rect.top;
+          modalWidth = rect.width;
+          modalHeight = rect.height;
+        }
+        modal.dataset.dragging = "true";
+        container.dataset.dragging = "true";
+        handle.style.cursor = "grabbing";
+        isDragging = true;
+      }
       hasCustomPosition = true;
       updatePosition(event.clientX, event.clientY);
     }
@@ -825,22 +845,13 @@ var GameApp = (() => {
       }
       pointerId = event.pointerId;
       handle.setPointerCapture?.(pointerId);
-      let rect = modal.getBoundingClientRect();
-      if (modal.style.transform.includes("-50%")) {
-        modal.style.transform = "translate(0, 0)";
-        modal.style.left = `${rect.left}px`;
-        modal.style.top = `${rect.top}px`;
-        rect = modal.getBoundingClientRect();
-      }
+      const rect = modal.getBoundingClientRect();
       startPointerX = event.clientX;
       startPointerY = event.clientY;
       startLeft = rect.left;
       startTop = rect.top;
       modalWidth = rect.width;
       modalHeight = rect.height;
-      modal.dataset.dragging = "true";
-      container.dataset.dragging = "true";
-      handle.style.cursor = "grabbing";
       window.addEventListener("pointermove", handlePointerMove);
       window.addEventListener("pointerup", endDrag);
       window.addEventListener("pointercancel", endDrag);

--- a/scripts/ui/floatingWindow.js
+++ b/scripts/ui/floatingWindow.js
@@ -32,6 +32,7 @@ export function createFloatingWindow({ container, modal, handle }) {
   let modalWidth = 0;
   let modalHeight = 0;
   let hasCustomPosition = false;
+  let isDragging = false;
 
   container.classList.add("floating-overlay");
   modal.classList.add("floating-window");
@@ -63,6 +64,21 @@ export function createFloatingWindow({ container, modal, handle }) {
     modal.style.top = `${nextTop}px`;
   }
 
+  function convertToAbsolutePosition() {
+    if (!modal.style.transform.includes("-50%")) {
+      return;
+    }
+
+    const rect = modal.getBoundingClientRect();
+    modal.style.transform = "translate(0, 0)";
+    modal.style.left = `${rect.left}px`;
+    modal.style.top = `${rect.top}px`;
+    startLeft = rect.left;
+    startTop = rect.top;
+    modalWidth = rect.width;
+    modalHeight = rect.height;
+  }
+
   function ensureWithinViewportBounds() {
     const rect = modal.getBoundingClientRect();
     const availableWidth = window.innerWidth;
@@ -90,8 +106,11 @@ export function createFloatingWindow({ container, modal, handle }) {
     handle.releasePointerCapture?.(pointerId);
     pointerId = null;
     handle.style.cursor = "grab";
-    modal.dataset.dragging = "false";
-    container.dataset.dragging = "false";
+    if (isDragging) {
+      modal.dataset.dragging = "false";
+      container.dataset.dragging = "false";
+    }
+    isDragging = false;
     window.removeEventListener("pointermove", handlePointerMove);
     window.removeEventListener("pointerup", endDrag);
     window.removeEventListener("pointercancel", endDrag);
@@ -103,6 +122,13 @@ export function createFloatingWindow({ container, modal, handle }) {
       return;
     }
     event.preventDefault();
+    if (!isDragging) {
+      convertToAbsolutePosition();
+      modal.dataset.dragging = "true";
+      container.dataset.dragging = "true";
+      handle.style.cursor = "grabbing";
+      isDragging = true;
+    }
     hasCustomPosition = true;
     updatePosition(event.clientX, event.clientY);
   }
@@ -116,22 +142,13 @@ export function createFloatingWindow({ container, modal, handle }) {
     }
     pointerId = event.pointerId;
     handle.setPointerCapture?.(pointerId);
-    let rect = modal.getBoundingClientRect();
-    if (modal.style.transform.includes("-50%")) {
-      modal.style.transform = "translate(0, 0)";
-      modal.style.left = `${rect.left}px`;
-      modal.style.top = `${rect.top}px`;
-      rect = modal.getBoundingClientRect();
-    }
+    const rect = modal.getBoundingClientRect();
     startPointerX = event.clientX;
     startPointerY = event.clientY;
     startLeft = rect.left;
     startTop = rect.top;
     modalWidth = rect.width;
     modalHeight = rect.height;
-    modal.dataset.dragging = "true";
-    container.dataset.dragging = "true";
-    handle.style.cursor = "grabbing";
     window.addEventListener("pointermove", handlePointerMove);
     window.addEventListener("pointerup", endDrag);
     window.addEventListener("pointercancel", endDrag);


### PR DESCRIPTION
## Summary
- delay conversion from centered to absolute positioning until a drag actually starts
- update the fallback bundle with the same drag handling improvements

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e5eb9c4ce8832dba553ed7ac5572bc