### PR TITLE
Fix modal dragging to follow pointer movement

### DIFF
--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -745,10 +745,8 @@ var GameApp = (() => {
       };
     }
     let pointerId = null;
-    let startPointerX = 0;
-    let startPointerY = 0;
-    let startLeft = 0;
-    let startTop = 0;
+    let offsetX = 0;
+    let offsetY = 0;
     let modalWidth = 0;
     let modalHeight = 0;
     let hasCustomPosition = false;
@@ -773,16 +771,25 @@ var GameApp = (() => {
       };
     }
     function updatePosition(clientX, clientY) {
-      const deltaX = clientX - startPointerX;
-      const deltaY = clientY - startPointerY;
       const availableWidth = window.innerWidth;
       const availableHeight = window.innerHeight;
       const { min: minLeft, max: maxLeft } = computeBounds(modalWidth, availableWidth);
       const { min: minTop, max: maxTop } = computeBounds(modalHeight, availableHeight);
-      const nextLeft = clamp(startLeft + deltaX, minLeft, maxLeft);
-      const nextTop = clamp(startTop + deltaY, minTop, maxTop);
+      const nextLeft = clamp(clientX - offsetX, minLeft, maxLeft);
+      const nextTop = clamp(clientY - offsetY, minTop, maxTop);
       modal.style.left = `${nextLeft}px`;
       modal.style.top = `${nextTop}px`;
+    }
+    function convertToAbsolutePosition() {
+      const rect = modal.getBoundingClientRect();
+      if (modal.style.transform.includes("-50%")) {
+        modal.style.transform = "translate(0, 0)";
+        modal.style.left = `${rect.left}px`;
+        modal.style.top = `${rect.top}px`;
+      }
+      modalWidth = rect.width;
+      modalHeight = rect.height;
+      return rect;
     }
     function ensureWithinViewportBounds() {
       const rect = modal.getBoundingClientRect();
@@ -790,6 +797,8 @@ var GameApp = (() => {
       const availableHeight = window.innerHeight;
       const { min: minLeft, max: maxLeft } = computeBounds(rect.width, availableWidth);
       const { min: minTop, max: maxTop } = computeBounds(rect.height, availableHeight);
+      modalWidth = rect.width;
+      modalHeight = rect.height;
       if (modal.style.transform.includes("-50%")) {
         return;
       }
@@ -821,16 +830,6 @@ var GameApp = (() => {
       }
       event.preventDefault();
       if (!isDragging) {
-        if (modal.style.transform.includes("-50%")) {
-          const rect = modal.getBoundingClientRect();
-          modal.style.transform = "translate(0, 0)";
-          modal.style.left = `${rect.left}px`;
-          modal.style.top = `${rect.top}px`;
-          startLeft = rect.left;
-          startTop = rect.top;
-          modalWidth = rect.width;
-          modalHeight = rect.height;
-        }
         modal.dataset.dragging = "true";
         container.dataset.dragging = "true";
         handle.style.cursor = "grabbing";
@@ -848,13 +847,12 @@ var GameApp = (() => {
       }
       pointerId = event.pointerId;
       handle.setPointerCapture?.(pointerId);
-      const rect = modal.getBoundingClientRect();
-      startPointerX = event.clientX;
-      startPointerY = event.clientY;
-      startLeft = rect.left;
-      startTop = rect.top;
-      modalWidth = rect.width;
-      modalHeight = rect.height;
+      const rect = convertToAbsolutePosition();
+      const { left, top, width, height } = rect;
+      offsetX = event.clientX - left;
+      offsetY = event.clientY - top;
+      modalWidth = width;
+      modalHeight = height;
       window.addEventListener("pointermove", handlePointerMove);
       window.addEventListener("pointerup", endDrag);
       window.addEventListener("pointercancel", endDrag);


### PR DESCRIPTION
## Summary
- adjust floating modal drag logic to use pointer offsets so panels track the cursor smoothly
- keep modal dimensions updated while enforcing viewport bounds during drags and resizes

## Testing
- npm run build:fallback

------
https://chatgpt.com/codex/tasks/task_e_68e65475796c832d9828de4e40c488f5