### PR TITLE
Make stats and journal modals draggable floating panels

### DIFF
--- a/scripts/ui/journal.js
+++ b/scripts/ui/journal.js
@@ -71,6 +71,11 @@ export function initializeJournal(button, panel, provider) {
     describedBy: BODY_ID,
     size: "wide",
     tone: "ember",
+    trapFocus: false,
+    closeOnBackdrop: false,
+    lockScroll: false,
+    draggable: true,
+    dragHandle: ".journal-modal__header",
     onOpen: handleModalOpen,
     onClose: handleModalClose,
   });

--- a/scripts/ui/statsPanel.js
+++ b/scripts/ui/statsPanel.js
@@ -45,6 +45,11 @@ export function initializeStatsUI(container, stats, options = {}) {
     labelledBy: TITLE_ID,
     size: "wide",
     tone: "midnight",
+    trapFocus: false,
+    closeOnBackdrop: false,
+    lockScroll: false,
+    draggable: true,
+    dragHandle: ".stats-modal__header",
     onRequestClose: () => {
       if (onRequestCloseRef) {
         onRequestCloseRef();

--- a/styles.css
+++ b/styles.css
@@ -797,9 +797,6 @@ body.modal-open {
 .modal-host {
   position: fixed;
   inset: 0;
-  display: grid;
-  place-items: center;
-  padding: clamp(16px, 6vh, 64px);
   z-index: 60;
   pointer-events: none;
   opacity: 0;
@@ -811,20 +808,22 @@ body.modal-open {
 }
 
 .modal-host[data-open="true"] {
-  pointer-events: auto;
   opacity: 1;
+}
+
+.modal-host[data-modal-overlay="scrim"][data-open="true"] {
+  pointer-events: auto;
 }
 
 .modal-layer {
   position: relative;
   width: 100%;
   height: 100%;
-  display: grid;
-  place-items: center;
+  pointer-events: none;
 }
 
 .modal-overlay {
-  position: absolute;
+  position: fixed;
   inset: clamp(0px, 4vh, 36px);
   border-radius: clamp(22px, 8vw, 36px);
   background:
@@ -856,13 +855,17 @@ body.modal-open {
 }
 
 .modal-surface {
-  position: relative;
+  position: fixed;
+  top: 50%;
+  left: 50%;
   width: min(100%, 760px);
   max-height: min(88vh, 780px);
   border-radius: clamp(22px, 4vw, 34px);
   overflow: hidden;
   opacity: 0;
-  transform: translateY(18px) scale(0.96);
+  transform:
+    translate(calc(-50% + var(--modal-offset-x, 0px)), calc(-50% + var(--modal-offset-y, 0px)))
+    scale(0.96);
   transition: opacity 260ms ease, transform 340ms cubic-bezier(0.18, 0.89, 0.32, 1.28);
   display: flex;
   flex-direction: column;
@@ -870,6 +873,7 @@ body.modal-open {
   -webkit-backdrop-filter: blur(24px) saturate(130%);
   box-shadow: 0 26px 70px rgba(5, 6, 22, 0.48), 0 12px 32px rgba(5, 6, 22, 0.32);
   border: 1px solid rgba(255, 255, 255, 0.12);
+  pointer-events: auto;
 }
 
 .modal-host[data-modal-size="wide"] .modal-surface {
@@ -887,14 +891,33 @@ body.modal-open {
 
 .modal-host[data-open="true"] .modal-surface {
   opacity: 1;
-  transform: translateY(0) scale(1);
+  transform:
+    translate(calc(-50% + var(--modal-offset-x, 0px)), calc(-50% + var(--modal-offset-y, 0px)))
+    scale(1);
+}
+
+.modal-surface.is-dragging {
+  transition: none;
+  cursor: grabbing;
+}
+
+.modal-host[data-modal-mode="floating"] {
+  pointer-events: none;
+}
+
+.modal-host[data-modal-mode="floating"] .modal-overlay {
+  display: none;
+}
+
+.modal-host[data-modal-mode="floating"] .modal-layer {
+  pointer-events: none;
+}
+
+.modal-host[data-modal-mode="floating"] .modal-surface {
+  pointer-events: auto;
 }
 
 @media (max-width: 720px) {
-  .modal-host {
-    padding: clamp(12px, 5vh, 32px);
-  }
-
   .modal-overlay {
     inset: clamp(0px, 3vh, 24px);
     border-radius: clamp(18px, 10vw, 28px);
@@ -945,6 +968,13 @@ body.modal-open {
   padding: 1.85rem 2rem 1.35rem;
   background: var(--journal-header-bg);
   border-bottom: 1px solid var(--journal-modal-border);
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+
+.journal-modal__header:active {
+  cursor: grabbing;
 }
 
 .journal-modal__titles {
@@ -1033,6 +1063,13 @@ body.modal-open {
   padding: 1.6rem 1.8rem 1.2rem;
   background: var(--stats-header-bg);
   border-bottom: 1px solid var(--stats-modal-border);
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+
+.stats-modal__header:active {
+  cursor: grabbing;
 }
 
 .stats-modal__titles {


### PR DESCRIPTION
## Summary
- update the shared modal system to support floating, draggable dialogs without locking the game screen
- restyle modal surfaces to stay centered in the viewport and add drag affordances for stats and journal headers
- configure the stats and journal panels to use the new floating draggable behavior

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e661a3dc88832d8f03fccc1c974a6d